### PR TITLE
Implement github_deploy script for enhanced GitHub deployment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ If you don't have an Assertible account yet, you can
 
 ## Overview
 
-This README describes how to connect Assertible tests to GitHub
-deployment events using different providers. There are basically two
-ways to connect your web service's repository to GitHub deployment
+This README describes how to connect **Assertible** tests to
+**GitHub** deployment events using different providers. There are two
+ways to connect your web service repository to GitHub deployment
 events.
 
 1. Using a providers built-in integration
 
     Some providers have an integration which works without the need to
     add any extra code. For example, [Heroku](#-heroku) will
-    automatically post deployment events to GitHub.
+    automatically post deployment events to GitHub (/we've primary
+    tested with
+    [Heroku Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps)/).
 
 2. Custom script
 
@@ -44,19 +46,26 @@ events.
     CI pipeline w/ GitHub deployment events:
 
     The most basic way to use this integration is to use our limited
-    two line script:
+    two line script (copy it into your CI or manual deploy script):
 
     ```
     DEPLOY_ID=$(curl -XPOST --verbose "https://$GH_TOKEN@api.github.com/repos/$TRAVIS_REPO_SLUG/deployments" -H "Content-Type:application/json" --data '{"ref":"master", "auto_merge":false, "required_contexts": []}' | python -c "import json,sys;obj=json.load(sys.stdin);print obj['id'];")
-    curl -XPOST "https://$GH_TOKEN@api.github.com/repos/$TRAVIS_REPO_SLUG/deployments/$DEPLOY_ID/statuses" --data '{"state":"success"}'
+    curl -XPOST "https://$GH_TOKEN@api.github.com/repos/$REPO/deployments/$DEPLOY_ID/statuses" --data '{"state":"success"}'
     ```
 
-    For a more extensive set of features, you may with to use the
+    For a more comprehensive set of features, you may with to use the
     `github_deploy` script. It has several improvements over the short
     two-line script:
 
-    - Support for pending deployments
+    - Support for Pending deployments
+
     - Support for `environment_url`
+
+    Assertible uses the `environment_url` to dynamically identify the
+    host your web app is being served from. Assertible will then run
+    your tests against the service being deployed (as opposed to
+    testing your production service).
+
     - Support for `auto_inactive`
 
     Using the `github_deploy` script is For example:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ events.
 
     $ DEPLOY_ID=$(./github_deploy.sh $CIRCLE_SHA1 org/repo https://staging.url.com "pending")
 
-      .. run your build steps ...
+      .. run your deploy steps ...
 
     $ ./github_deploy.sh $CIRCLE_SHA1 org/repo https://staging.url.com "success" $DEPLOY_ID
     ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,52 @@ new deployments.
 If you don't have an Assertible account yet, you can
 [**sign up for free**](https://assertible.com/signup).
 
+## Overview
+
+This README describes how to connect Assertible tests to GitHub
+deployment events using different providers. There are basically two
+ways to connect your web service's repository to GitHub deployment
+events.
+
+1. Using a providers built-in integration
+
+    Some providers have an integration which works without the need to
+    add any extra code. For example, [Heroku](#-heroku) will
+    automatically post deployment events to GitHub.
+
+2. Custom script
+
+    This repo provides two custom scripts for integrating your repo's
+    CI pipeline w/ GitHub deployment events:
+
+    The most basic way to use this integration is to use our limited
+    two line script:
+
+    ```
+    DEPLOY_ID=$(curl -XPOST --verbose "https://$GH_TOKEN@api.github.com/repos/$TRAVIS_REPO_SLUG/deployments" -H "Content-Type:application/json" --data '{"ref":"master", "auto_merge":false, "required_contexts": []}' | python -c "import json,sys;obj=json.load(sys.stdin);print obj['id'];")
+    curl -XPOST "https://$GH_TOKEN@api.github.com/repos/$TRAVIS_REPO_SLUG/deployments/$DEPLOY_ID/statuses" --data '{"state":"success"}'
+    ```
+
+    For a more extensive set of features, you may with to use the
+    `github_deploy` script. It has several improvements over the short
+    two-line script:
+
+    - Support for pending deployments
+    - Support for `environment_url`
+    - Support for `auto_inactive`
+
+    Using the `github_deploy` script is For example:
+
+    ```
+    $ export GH_TOKEN=lk34j234
+
+    $ DEPLOY_ID=$(./github_deploy.sh $CIRCLE_SHA1 org/repo https://staging.url.com "pending")
+
+      .. run your build steps ...
+
+    $ ./github_deploy.sh $CIRCLE_SHA1 org/repo https://staging.url.com "success" $DEPLOY_ID
+    ```
+
 ## Configurations
 
 Find your continuous integration or deployments provider below to see

--- a/github_deploy
+++ b/github_deploy
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Usage:
+#
+#    required env vars
+#    GH_TOKEN=lk34j234
+#
+#    $ DEPLOY_ID=$(./github_deploy.sh $CIRCLE_SHA1 assertible/repo https://staging.app.com "pending")
+#
+#    $ ./github_deploy.sh $CIRCLE_SHA1 assertible/repo https://staging.app.com "success" $DEPLOY_ID
+#
+# Notes:
+#   - This script is designed to be light-weight and work under any CI
+#     environment w/ bash & python.
+#
+#   - This script uses features from the GitHub developer preview
+#     "ant-man-preview" <https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/>. In practice, this means that the "environment_url" &
+#     "auto_inactive" are used when possible.
+
+SHA1=$1
+REPO=$2
+ENVIRONMENT_URL=$3
+STATUS=${4:-success}
+DEPLOY_ID=${5}
+DEPLOY_URL="https://$GH_TOKEN@api.github.com/repos/$REPO/deployments"
+
+CONTENT_TYPE_HEADER="Content-Type:application/json"
+
+# Use the deployment developer preview, if available. If the
+# ant-man-preview is not available, some POST'ed fields will have no
+# effect (environment_url, auto_inactive, etc)
+ACCEPT_HEADER="Accept:application/vnd.github.ant-man-preview+json,application,json"
+
+if [[ "$DEPLOY_ID" ]]
+then
+
+    DEPLOY_STATUS_URL="https://$GH_TOKEN@api.github.com/repos/$REPO/deployments/$DEPLOY_ID/statuses"
+    curl -s -XPOST ${DEPLOY_STATUS_URL} -H ${CONTENT_TYPE_HEADER} -H ${ACCEPT_HEADER} \
+         --data '{ "environment_url":"'"$ENVIRONMENT_URL"'", "state":"'"$STATUS"'", "auto_inactive": true }'
+
+else
+
+    DEPLOY_ID=$(curl -XPOST -s $DEPLOY_URL -H ${CONTENT_TYPE_HEADER} -H ${ACCEPT_HEADER} \
+                     --data '{"ref":"'"$SHA1"'", "environment":"staging", "auto_merge":false, "required_contexts": [], "payload": "{\"url\":\"https://some.environment.url.com\"}"}' \
+                       | python -c "import json,sys;obj=json.load(sys.stdin);print obj['id'];")
+
+    DEPLOY_STATUS_URL="https://$GH_TOKEN@api.github.com/repos/$REPO/deployments/$DEPLOY_ID/statuses"
+
+    curl -s -XPOST ${DEPLOY_STATUS_URL} -H ${CONTENT_TYPE_HEADER} -H ${ACCEPT_HEADER} \
+         --data '{ "environment_url":"'"$ENVIRONMENT_URL"'", "state":"'"$STATUS"'", "auto_inactive": true }' > /dev/null
+
+    echo $DEPLOY_ID
+
+fi

--- a/github_deploy
+++ b/github_deploy
@@ -23,7 +23,7 @@ ENVIRONMENT_URL=$3
 STATUS=${4:-success}
 DEPLOY_ID=${5}
 DEPLOY_URL="https://$GH_TOKEN@api.github.com/repos/$REPO/deployments"
-
+ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-staging}
 CONTENT_TYPE_HEADER="Content-Type:application/json"
 
 # Use the deployment developer preview, if available. If the
@@ -41,7 +41,7 @@ then
 else
 
     DEPLOY_ID=$(curl -XPOST -s $DEPLOY_URL -H ${CONTENT_TYPE_HEADER} -H ${ACCEPT_HEADER} \
-                     --data '{"ref":"'"$SHA1"'", "environment":"staging", "auto_merge":false, "required_contexts": [], "payload": "{\"url\":\"https://some.environment.url.com\"}"}' \
+                     --data '{"ref":"'"$SHA1"'", "environment":"'"$ENVIRONMENT_NAME"'", "auto_merge":false, "required_contexts": [], "payload": "{}"}' \
                        | python -c "import json,sys;obj=json.load(sys.stdin);print obj['id'];")
 
     DEPLOY_STATUS_URL="https://$GH_TOKEN@api.github.com/repos/$REPO/deployments/$DEPLOY_ID/statuses"


### PR DESCRIPTION
- [x] improve copy
- [x] test
- [x] parameterize `environment` name
- [x] implement support for passing `environment_url` through payload when it's not provided elsewhere (or using the ant-man-preview)